### PR TITLE
Backport Radius' save bios settings

### DIFF
--- a/src/burn/devices/eeprom.c
+++ b/src/burn/devices/eeprom.c
@@ -96,7 +96,7 @@ void EEPROMInit(const eeprom_interface *interface)
 #else
    char slash = '/';
 #endif
-	snprintf (output, sizeof(output), "%s%c%s.nv", g_rom_dir, slash, BurnDrvGetTextA(DRV_NAME));
+	snprintf (output, sizeof(output), "%s%c%s.nv", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
 #else
 	snprintf (output, sizeof(output), "config/games/%s.nv", BurnDrvGetTextA(DRV_NAME));
 #endif
@@ -126,7 +126,7 @@ void EEPROMExit()
 #else
    char slash = '/';
 #endif
-	snprintf (output, sizeof(output), "%s%c%s.nv", g_rom_dir, slash, BurnDrvGetTextA(DRV_NAME));
+	snprintf (output, sizeof(output), "%s%c%s.nv", g_save_dir, slash, BurnDrvGetTextA(DRV_NAME));
 #else
 	snprintf (output, sizeof(output), "config/games/%s.nv", BurnDrvGetTextA(DRV_NAME));
 #endif

--- a/src/burner/libretro/burn_libretro_opts.h
+++ b/src/burner/libretro/burn_libretro_opts.h
@@ -12,5 +12,6 @@
 #endif
 
 extern char g_rom_dir[1024];
+extern char g_save_dir[1024];
 
 #endif


### PR DESCRIPTION
Tested on Wii.

Saves to root, I can't seem to change that via RGUI, either way I would change it in the code to "sd:/retroarch/system/%s%c%s.fs" but I don't think that's my call.
