### PR TITLE
Map neogeo "select" button to R2

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -3014,7 +3014,7 @@ static INT32 GameInpAutoOne(struct GameInp* pgi, char* szi, char *szn)
 		if(bButtonMapped) return 0;
 
 		if (strncmp("select", szb, 6) == 0)
-			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_JOYPAD_SELECT, description);
+			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_JOYPAD_R2, description);
 		if (strncmp("coin", szb, 4) == 0)
 			GameInpDigital2RetroInpKey(pgi, nPlayer, RETRO_DEVICE_ID_JOYPAD_SELECT, description);
 		if (strncmp("start", szb, 5) == 0)


### PR DESCRIPTION
2019-07-03 : Actually, map it to R2, it not only fixes the insert coin sound, but also allows access to a menu in last blade training mode.
Backport from https://github.com/libretro/FBNeo/commit/666d7f04f9018c4e9a5f1c216d49c81ae9e0dd08.