### PR TITLE
Fix makefile.libretro

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -127,7 +127,7 @@ else ifneq (,$(findstring ios,$(platform)))
    endif
 
 # tvOS
-else if ($(platform), tvos-arm64)
+else ifeq ($(platform), tvos-arm64)
    TARGET := $(TARGET_NAME)_libretro_tvos.dylib
    fpic := -fPIC
    SHARED := -dynamiclib


### PR DESCRIPTION
Here's the error I got with else if  :
makefile.libretro:130: extraneous text after 'else' directive
make: xcodebuild: Command not found
