### PR TITLE
Fix kof2003

### DIFF
--- a/src/burn/drv/neogeo/d_neogeo.cpp
+++ b/src/burn/drv/neogeo/d_neogeo.cpp
@@ -9069,8 +9069,8 @@ STD_ROM_FN(kof2003)
 
 static void kof2003Callback()
 {
-#ifdef WII_VM
-// Copied from the latest FBA, else it will crash on Wii.
+	/* Copied from the latest FBA, else it will cause memory
+	 * violations that produce undefined behaviour */
 	INT32 i, j, k;
 	for (i = 0; i < 0x100000; i++)
 		Neo68KROMActive[i] ^= ~Neo68KROMActive[0x0fffe0 + (i & 0x1f)];
@@ -9108,45 +9108,6 @@ static void kof2003Callback()
 
 		memmove (Neo68KROMActive + i, Neo68KROMActive + 0x100000, 0x100000);
 	}
-#else
-	INT32 i, j, k;
-	for (i = 0; i < 0x100000; i++)
-		Neo68KROMActive[i] ^= ~Neo68KROMActive[0x0fffe0 + (i & 0x1f)];
-
-	for (i = 0; i < 0x100000; i++)
-	        Neo68KROMActive[0x800000 + i] ^= Neo68KROMActive[0x100002 | i];
-
-	for (i = 0x100000; i < 0x800000; i++)
-		Neo68KROMActive[i] ^= ~Neo68KROMActive[0x7fffe0 + (i & 0x1f)];
-
-	for (i = 0x100000; i < 0x800000; i += 4) {
-		UINT16 rom16 = BURN_ENDIAN_SWAP_INT16(*((UINT16 *)(Neo68KROMActive + i + 1)));
-		rom16 = BITSWAP16(rom16, 15, 14, 13, 12, 5, 4, 7, 6, 9, 8, 11, 10, 3, 2, 1, 0);
-		*((UINT16 *)(Neo68KROMActive + i + 1)) = BURN_ENDIAN_SWAP_INT16(rom16);
-	}
-
-	memcpy (Neo68KROMActive + 0x700000, Neo68KROMActive, 0x100000);
-
-	for (i = 0; i < 0x0100000 / 0x10000; i++) {
-		j = BITSWAP08(i, 7, 6, 5, 4, 0, 1, 2, 3);
-		memcpy (Neo68KROMActive + i * 0x010000, Neo68KROMActive + 0x700000 + j * 0x010000, 0x010000);
-	}
-
-	memcpy (Neo68KROMActive + 0x200000, Neo68KROMActive + 0x100000, 0x600000);
-
-	for (i = 0x200000; i < 0x900000; i += 0x100000)
-	{
-		for (j = 0; j < 0x100000; j += 0x100)
-		{
-			k  = (j & 0xf00) ^ 0x00800;
-			k |= BITSWAP08(j >> 12, 4, 5, 6, 7, 1, 0, 3, 2 ) << 12;
-
-			memcpy (Neo68KROMActive + 0x100000 + j, Neo68KROMActive + i + k, 0x100);
-		}
-
-		memcpy (Neo68KROMActive + i, Neo68KROMActive + 0x100000, 0x100000);
-	}
-#endif
 }
 
 static INT32 kof2003Init()


### PR DESCRIPTION
There is at present a Wii-specific crash fix for the game `The King of Fighters 2003` - on this platform, the `kof2003Callback()` function is copied from the 'latest' FBA code, while everywhere else it uses the 2012 version.

It turns out that this fix is required on *all* platforms. The 'old' implementation of this function includes memory access violations that cause undefined behaviour. It just so happened that this produced an obvious crash on the Wii, but silent corruption happens everywhere - sometimes the game just doesn't work properly, sometimes RetroArch crashes at a random point after closing the content. Nasty stuff.

This PR just removes the Wii-specific `#ifdef`, so `The King of Fighters 2003` now works on all platforms.