### PR TITLE
(3DS) Use custom burn_memory.cpp

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -256,6 +256,7 @@ else ifeq ($(platform), ctr)
    PLATFORM_DEFINES += -march=armv6k -mtune=mpcore -mfloat-abi=hard
    PLATFORM_DEFINES += -Wall -mword-relocations
    PLATFORM_DEFINES += -fomit-frame-pointer -ffast-math
+   CFLAGS += -I$(DEVKITPRO)/libctru/include
    CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
    CPU_ARCH := arm
    STATIC_LINKING = 1
@@ -435,6 +436,10 @@ endif
 
 FBA_SRC_DIRS := $(FBA_BURNER_DIR) $(FBA_BURN_DIRS) $(FBA_CPU_DIRS)
 
+ifeq ($(platform), ctr)
+	BURN_BLACKLIST += $(FBA_BURN_DIR)/burn_memory.cpp
+	FBA_SRC_DIRS += $(LIBRETRO_DIR)/ctr
+endif
 
 ifeq ($(EXTERNAL_ZLIB), 1)
    FBA_DEFINES += -DEXTERNAL_ZLIB

--- a/src/burner/libretro/ctr/burn_memory.cpp
+++ b/src/burner/libretro/ctr/burn_memory.cpp
@@ -1,0 +1,178 @@
+// FB Alpha memory management module
+
+// The purpose of this module is to offer replacement functions for standard C/C++ ones
+// that allocate and free memory.  This should help deal with the problem of memory
+// leaks and non-null pointers on game exit.
+#include <cstdio>
+#include "burnint.h"
+
+#if 1
+#include "3ds.h"
+#else
+typedef struct {
+    UINT32 base_addr;
+    UINT32 size;
+    UINT32 perm;
+    UINT32 state;
+} MemInfo;
+typedef struct {
+    UINT32 flags;
+} PageInfo;
+
+#define MEMOP_FREE            0x1
+#define MEMOP_ALLOC           0x3
+#define MEMOP_ALLOC_LINEAR    0x10003
+#define MEMPERM_READ          0x1
+#define MEMPERM_WRITE         0x2
+#define MEMSTATE_FREE         0x0
+
+INT32 svcQueryMemory(MemInfo* info, PageInfo* out, UINT32 addr);
+INT32 svcControlMemory(UINT32* addr_out, UINT32 addr0, UINT32 addr1, UINT32 size, UINT32 op, UINT32 perm);
+
+#endif
+
+#define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);}while(0)
+#define DEBUG_VAR(X) printf( "%-20s: 0x%08lX\n", #X, (uint32_t)(X))
+#define DEBUG_VAR64(X) printf( #X"\r\t\t\t\t : 0x%016llX\n", (uint64_t)(X))
+
+#define MAX_MEM_PTR	0x400 // more than 1024 malloc calls should be insane...
+
+static UINT8 *memptr[MAX_MEM_PTR]; // pointer to allocated memory
+static UINT32 memsize[MAX_MEM_PTR];
+
+// this should be called early on... BurnDrvInit?
+
+static unsigned int total_size = 0;
+
+char debug_str[256];
+
+void BurnInitMemoryManager(void)
+{
+   memset (memptr, 0, MAX_MEM_PTR * sizeof(UINT8 **));
+   memset (memsize, 0, MAX_MEM_PTR * sizeof(UINT32 *));
+   total_size = 0;
+}
+
+// should we pass the pointer as a variable here so that we can save a pointer to it
+// and then ensure it is NULL'd in BurnFree or BurnExitMemoryManager?
+
+/* can be defined by the frontend to free memory when possible/needed */
+extern __attribute((weak)) void ctr_request_free_pages(UINT32 pages);
+
+UINT32 ctr_get_mappable_range(UINT32 pages)
+{
+   MemInfo mem_info;
+   PageInfo page_info;
+   UINT32 size = pages << 12;
+   UINT32 addr = 0x10000000 - 0x1000;
+
+   while(addr > 0x08000000)
+   {
+      svcQueryMemory(&mem_info, &page_info, addr);
+
+      if((mem_info.state == MEMSTATE_FREE) && (mem_info.size > size))
+         return mem_info.base_addr + mem_info.size - size;
+
+      addr = mem_info.base_addr - 0x1000;
+   }
+
+   return 0;
+}
+
+// call instead of 'malloc'
+UINT8 *BurnMalloc(INT32 size)
+{
+   DEBUG_VAR(size);
+
+   if(!size)
+      return NULL;
+
+   for (INT32 i = 0; i < MAX_MEM_PTR; i++)
+   {
+      if (memptr[i] == NULL)
+      {
+         if((size&0xFFF) && (size < 0x400000))
+         {
+            memptr[i]  = (UINT8*)malloc(size);
+            memsize[i] = 0;
+         }
+         if (memptr[i] == NULL)
+         {
+            size = (size + 0xFFF) & ~0xFFF;
+
+            if(ctr_request_free_pages)
+               ctr_request_free_pages(size >> 12);
+
+            if(svcControlMemory((u32*)&memptr[i], 0, 0, size, MEMOP_ALLOC_LINEAR, (MemPerm)(MEMPERM_READ | MEMPERM_WRITE)) < 0)
+            {
+               UINT32 addr = ctr_get_mappable_range(size >> 12);
+               if(svcControlMemory((u32*)&memptr[i], addr, 0, size, MEMOP_ALLOC, (MemPerm)(MEMPERM_READ | MEMPERM_WRITE)) < 0)
+               {
+                  memptr[i] = NULL;
+                  printf("size       : 0x%08X\n", size);
+                  printf("total_size : 0x%08X\n", total_size);
+                  printf("BurnMalloc failed to allocate %d bytes of memory!\n", size);
+                  DEBUG_HOLD();
+                  exit(0);
+               }
+            }
+            memsize[i] = size;
+            total_size += size;
+         }
+
+         memset (memptr[i], 0, size); // set contents to 0
+         return memptr[i];
+      }
+   }
+
+   bprintf (0, _T("BurnMalloc called too many times!\n"));
+
+   return NULL; // Freak out!
+}
+
+void _BurnFree(void *ptr)
+{
+	UINT8 *mptr = (UINT8*)ptr;
+   void* tmp;
+
+   if(!ptr)
+      return;
+
+   for (INT32 i = 0; i < MAX_MEM_PTR; i++)
+   {
+      if (memptr[i] == mptr) {
+         if(!memsize[i])
+            free(memptr[i]);
+         else
+         {
+            svcControlMemory((u32*)&tmp, (u32)memptr[i], 0, memsize[i], MEMOP_FREE, (MemPerm) 0x0);
+            total_size -= memsize[i];
+            memsize[i]  = 0;
+         }
+         memptr[i]   = NULL;
+         break;
+      }
+   }
+}
+
+void BurnExitMemoryManager(void)
+{
+   void* tmp;
+	for (INT32 i = 0; i < MAX_MEM_PTR; i++)
+	{
+		if (memptr[i] != NULL) {
+#if defined FBA_DEBUG
+			bprintf(PRINT_ERROR, _T("BurnExitMemoryManager had to free mem pointer %i\n"), i);
+#endif
+         if(!memsize[i])
+            free(memptr[i]);
+         else
+   			svcControlMemory((u32*)&tmp, (u32)memptr[i], 0, memsize[i], MEMOP_FREE, (MemPerm)(MEMPERM_READ | MEMPERM_WRITE));
+
+         memptr[i] = NULL;
+         memsize[i] = 0;
+		}
+	}
+   total_size = 0;
+}
+


### PR DESCRIPTION
## Description
This PR re-implements the custom memory manager initially commited by @aliaspider. ( https://github.com/libretro/fbalpha2012_neogeo/commit/31d8537cdc58b9a9c664b84c6102f9526f428cbf https://github.com/libretro/fbalpha2012_neogeo/commit/c4e1bda575831024c2d1c77abfc1418fc241eb52  )

This allows the larger ROMs to load again, with the exception of the ROMs using the ```NEO-PCM2, type 2``` audio chip.
These ROMs will cause an 'out of memory' error on which retroarch exits, instead of raising an ARM exception or run with distorted audio.

All supported ROMs i've been able to test load up and run great, on a New3DS.

## Related Issue
https://github.com/libretro/fbalpha2012_neogeo/issues/39



